### PR TITLE
Update TypeScript to 6.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,13 @@
                 "glob": "11.1.0",
                 "parse5": "5 - 6",
                 "pofile": "^1.1.0",
-                "typescript": "^5.4.0"
+                "typescript": "^6.0.0"
             },
             "devDependencies": {
                 "@types/jest": "^30.0.0",
                 "@types/node": "^20.9.0",
                 "jest": "^30.0.0",
-                "ts-jest": "^29.4.0",
+                "ts-jest": "^29.4.12",
                 "tslint": "^5.11.0"
             },
             "engines": {
@@ -4844,9 +4844,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "css-selector-parser": "^1.3",
                 "glob": "11.1.0",
                 "parse5": "5 - 6",
-                "pofile": "1.0.x",
+                "pofile": "^1.1.0",
                 "typescript": "^5.4.0"
             },
             "devDependencies": {
@@ -1667,13 +1667,6 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "node_modules/async": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/babel-code-frame": {
             "version": "6.22.0",
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
@@ -2279,22 +2272,6 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "license": "MIT"
         },
-        "node_modules/ejs": {
-            "version": "3.1.10",
-            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-            "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "jake": "^10.8.5"
-            },
-            "bin": {
-                "ejs": "bin/cli.js"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/electron-to-chromium": {
             "version": "1.5.181",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.181.tgz",
@@ -2450,29 +2427,6 @@
                 "bser": "2.1.1"
             }
         },
-        "node_modules/filelist": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-            "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "minimatch": "^5.0.1"
-            }
-        },
-        "node_modules/filelist/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/fill-range": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2610,6 +2564,28 @@
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/handlebars": {
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.2",
+                "source-map": "^0.6.1",
+                "wordwrap": "^1.0.0"
+            },
+            "bin": {
+                "handlebars": "bin/handlebars"
+            },
+            "engines": {
+                "node": ">=0.4.7"
+            },
+            "optionalDependencies": {
+                "uglify-js": "^3.1.4"
+            }
         },
         "node_modules/has-ansi": {
             "version": "2.0.0",
@@ -2859,49 +2835,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/jake": {
-            "version": "10.9.2",
-            "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-            "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "async": "^3.2.3",
-                "chalk": "^4.0.2",
-                "filelist": "^1.0.4",
-                "minimatch": "^3.1.2"
-            },
-            "bin": {
-                "jake": "bin/cli.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/jake/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/jake/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/jest": {
@@ -3844,6 +3777,16 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/minipass": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -3880,6 +3823,13 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true,
             "license": "MIT"
         },
@@ -4137,9 +4087,10 @@
             }
         },
         "node_modules/pofile": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/pofile/-/pofile-1.0.11.tgz",
-            "integrity": "sha512-Vy9eH1dRD9wHjYt/QqXcTz+RnX/zg53xK+KljFSX30PvdDMb2z+c6uDUeblUGqqJgz3QFsdlA0IJvHziPmWtQg=="
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/pofile/-/pofile-1.1.4.tgz",
+            "integrity": "sha512-r6Q21sKsY1AjTVVjOuU02VYKVNQGJNQHjTIvs4dEbeuuYfxgYk/DGD2mqqq4RDaVkwdSq0VEtmQUOPe/wH8X3g==",
+            "license": "MIT"
         },
         "node_modules/pretty-format": {
             "version": "30.0.2",
@@ -4607,19 +4558,19 @@
             }
         },
         "node_modules/ts-jest": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
-            "integrity": "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==",
+            "version": "29.4.12",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+            "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bs-logger": "^0.2.6",
-                "ejs": "^3.1.10",
                 "fast-json-stable-stringify": "^2.1.0",
+                "handlebars": "^4.7.9",
                 "json5": "^2.2.3",
                 "lodash.memoize": "^4.1.2",
                 "make-error": "^1.3.6",
-                "semver": "^7.7.2",
+                "semver": "^7.8.5",
                 "type-fest": "^4.41.0",
                 "yargs-parser": "^21.1.1"
             },
@@ -4636,7 +4587,7 @@
                 "babel-jest": "^29.0.0 || ^30.0.0",
                 "jest": "^29.0.0 || ^30.0.0",
                 "jest-util": "^29.0.0 || ^30.0.0",
-                "typescript": ">=4.3 <6"
+                "typescript": ">=4.3 <7"
             },
             "peerDependenciesMeta": {
                 "@babel/core": {
@@ -4660,9 +4611,9 @@
             }
         },
         "node_modules/ts-jest/node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -4893,9 +4844,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -4903,6 +4854,20 @@
             },
             "engines": {
                 "node": ">=14.17"
+            }
+        },
+        "node_modules/uglify-js": {
+            "version": "3.19.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
             }
         },
         "node_modules/undici-types": {
@@ -5017,6 +4982,13 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/wrap-ansi": {
             "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
         "glob": "11.1.0",
         "parse5": "5 - 6",
         "pofile": "^1.1.0",
-        "typescript": "^5.4.0"
+        "typescript": "^6.0.0"
     },
     "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^20.9.0",
         "jest": "^30.0.0",
-        "ts-jest": "^29.4.0",
+        "ts-jest": "^29.4.12",
         "tslint": "^5.11.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "css-selector-parser": "^1.3",
         "glob": "11.1.0",
         "parse5": "5 - 6",
-        "pofile": "1.0.x",
+        "pofile": "^1.1.0",
         "typescript": "^5.4.0"
     },
     "devDependencies": {

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -1,5 +1,8 @@
 import * as fs from 'fs';
-import * as pofile from 'pofile';
+import PO = require('pofile');
+
+type PoHeaders = PO['headers'];
+type PoItem = InstanceType<typeof PO.Item>;
 
 import { CatalogBuilder, IContext, IMessage } from './builder';
 import { JsParser, IJsExtractorFunction } from './js/parser';
@@ -67,10 +70,10 @@ export class GettextExtractor {
         return this.builder.getMessagesByContext(context);
     }
 
-    public getPotString(headers: Partial<pofile.IHeaders> = {}): string {
+    public getPotString(headers: PoHeaders = {}): string {
         Validate.optional.object({headers});
 
-        let po = new (<any>pofile)();
+        let po = new PO();
         po.items = this.getPofileItems();
         po.headers = {
           'Content-Type': 'text/plain; charset=UTF-8',
@@ -79,14 +82,14 @@ export class GettextExtractor {
         return po.toString();
     }
 
-    public savePotFile(fileName: string, headers?: Partial<pofile.IHeaders>): void {
+    public savePotFile(fileName: string, headers?: PoHeaders): void {
         Validate.required.nonEmptyString({fileName});
         Validate.optional.object({headers});
 
         fs.writeFileSync(fileName, this.getPotString(headers));
     }
 
-    public savePotFileAsync(fileName: string, headers?: Partial<pofile.IHeaders>): Promise<any> {
+    public savePotFileAsync(fileName: string, headers?: PoHeaders): Promise<any> {
         Validate.required.nonEmptyString({fileName});
         Validate.optional.object({headers});
 
@@ -108,9 +111,9 @@ export class GettextExtractor {
         new StatsOutput(this.getStats()).print();
     }
 
-    private getPofileItems(): pofile.Item[] {
+    private getPofileItems(): PoItem[] {
         return this.getMessages().map(message => {
-            let item = new pofile.Item();
+            let item = new PO.Item();
 
             item.msgid = message.text as string;
             item.msgid_plural = message.textPlural as string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,13 @@
 {
     "compilerOptions": {
         "outDir": "dist/",
+        "rootDir": "src/",
         "target": "ES6",
         "module": "commonjs",
         "declaration": true,
         "newLine": "LF",
-        "strict": true
+        "strict": true,
+        "types": ["node", "jest"]
     },
     "files": [
         "src/index.ts"


### PR DESCRIPTION
Hi Michael! Thank you for this project. I've been using it in production without problems for years.

I recently audited my transitive deps and noticed it was still pulling TypeScript 5.x so my project ended up bringing in 3 different versions of the TS compiler (5, 6 and 7), so I migrated it to 6.x.

I also updated the `pofile` dependency since its old declarations no longer compiled under TypeScript 6.x.